### PR TITLE
Implemented the before_bootstrap method to provide a static IP addres…

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,18 +63,27 @@ Create a new server in the oVirt cluster based off an existing template. One of 
 
  * `--ovirt_cloud_init <cloud_init yaml>` specify a yaml string containing the cloud_init data needed to pass to the system.  One method is to do it this way in a the knife.rb config:
  ```ruby
- knife[:ovirt_cloud_init] = {
-   ssh_authorized_keys: [File.read("#{ENV['HOME']}/.ssh/ovirt.pub")],
-   user: knife[:ssh_user],
-   ip: knife[:bootstrap_ip_address],
-   netmask: '255.255.255.0',
-   gateway: '192.168.1.1',
-   nicname: 'eth0',
-   dns: '192.168.1.1',
-   domain: 'example.com',
-   hostname: knife[:chef_node_name],
- }.to_yaml
+knife[:bootstrap_ip_address_temp]="#{ENV['BOOTSTRAP_IP_ADDRESS_ENV']}"
+knife[:ovirt_cloud_init] = {
+  ssh_authorized_keys: [File.read("#{ENV['HOME']}/.ssh/id_rsa.pub")],
+  ip: knife[:bootstrap_ip_address_temp],
+  netmask: '255.255.255.0',
+  gateway: '192.168.250.1',
+  nicname: 'ens3',
+  dns: '192.168.250.200',
+  domain: 'example.com',
+  hostname: knife[:chef_node_name],
+#  custom_script: File.read("#{ENV['HOME']}/.chef/cloud-init-ubuntu.yaml")
+}.to_yaml
  ```
+
+You then create and bootstrap a new server like this:
+ ```bash
+BOOTSTRAP_IP_ADDRESS_ENV=192.168.250.241 knife ovirt server create --ssh-user root --identity-file ~/.ssh/id_rsa --no-host-key-verify -N node-name --ovirt-template-name template-name -r 'role[name]'
+ ```
+TODO: support IP addresses obtained from DHCP and reported to oVirt by ovirt-guest-agent
+
+TODO: refactor to work with Chef 15; for now this gem depends on knife-cloud-1.2.3, which is not compatible. Made to work by reverting attribute names from https://github.com/chef/knife-cloud/pull/117/files and manually fixing some dependencies.
 
 ### `knife ovirt server delete VMID|VMNAME [VMID|VMNAME] (options)`
 

--- a/lib/chef/knife/ovirt_server_create.rb
+++ b/lib/chef/knife/ovirt_server_create.rb
@@ -21,6 +21,20 @@ class Chef
 
         banner 'knife ovirt server create (options)'
 
+        def before_bootstrap
+          super
+
+          bootstrap_ip_address = "#{ENV['BOOTSTRAP_IP_ADDRESS_ENV']}"
+
+          Chef::Log.debug("Bootstrap IP Address: #{bootstrap_ip_address}")
+          if bootstrap_ip_address.nil?
+            error_message = "No IP address available for bootstrapping."
+            ui.error(error_message)
+            raise CloudExceptions::BootstrapError, error_message
+          end
+          config[:bootstrap_ip_address] = bootstrap_ip_address
+        end
+
         def before_exec_command
           super
           # setup the create options


### PR DESCRIPTION
Without this, the knife bootstrap method has no clue where the newly bootstrapped server is. 
It would be much nicer to actually read the value from oVirt, but my use case is fixed IP addresses, so I'm happy.
There is more work that needs to be done to make this gem up to date with Chef 15. But my other changes were to knife-cloud 1.2.3: /lib/chef/knife/cloud/chefbootstrap
reverting attribute changes from https://github.com/chef/knife-cloud/pull/117/files

and chef 15.2.20: /lib/chef/knife/bootstrap.rb
`
+require "chef/knife/bootstrap/train_connector"
+require "chef/knife/bootstrap/chef_vault_handler"
`
and the bootstrap template:
missing "channel" attribute changed to "stable" by hand
